### PR TITLE
Added Authentication support and POST request body parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,12 @@ And in the case of faliure you will get the reason why it failed (curl_error dir
 }
 ```
 
-### Checking Proxies with authentication
-My fork supports Proxy authentication.
+### Checking Proxies with Authentication
 To check a proxy that requires authentication you need to pass the login and password to the request.
 This works on both SOCKS and HTTP proxies. Example:
 ```
 checker.php?ip=137.116.76.252&port=3128&timeout=20&login=foo&password=bar
 ```
-Currently only supported for CheckSingleProxy
 
 #### Checking SOCKS Proxies
 If you are using version 1.2 you will also be able to check SOCKS4/5 proxies. In version 1.2 the proxy is checked for SOCKS by default after it has partially failed a check for HTTP (Connection reset error), however knowing for sure whether it is a SOCKS proxy you are about to check or no can minimise the time it will take to process.
@@ -76,6 +74,18 @@ To check a list of proxies contained in file `abc.txt` with a timeout of 20 seco
 ```
 localhost/checker.php?file=abc.txt&timeout=20
 ```
+
+#### Update: checking multiple proxies with a POST request
+To check multiple proxies with a POST request, you need to pass the following request body:]
+```json
+{ 
+    "timeout" : 20,
+    "proxy_type" : "http(s)",
+    "authentication" : true,
+    "proxies" : ["ip:port:login:password", "ip:port:anotherproxy:password"]
+}
+```
+This supports authentication and SOCKS proxies, based on the checkSingleProxy function.
 
 This uses multi-threading and hence instead of taking 200 seconds for 10 proxies 
 (20 secs timeout * 10 proxies), it will take roughly 30 seconds to finish.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ And in the case of faliure you will get the reason why it failed (curl_error dir
 }
 ```
 
+### Checking Proxies with authentication
+My fork supports Proxy authentication.
+To check a proxy that requires authentication you need to pass the login and password to the request.
+This works on both SOCKS and HTTP proxies. Example:
+```
+checker.php?ip=137.116.76.252&port=3128&timeout=20&login=foo&password=bar
+```
+Currently only supported for CheckSingleProxy
+
 #### Checking SOCKS Proxies
 If you are using version 1.2 you will also be able to check SOCKS4/5 proxies. In version 1.2 the proxy is checked for SOCKS by default after it has partially failed a check for HTTP (Connection reset error), however knowing for sure whether it is a SOCKS proxy you are about to check or no can minimise the time it will take to process.
 

--- a/checker.php
+++ b/checker.php
@@ -23,13 +23,20 @@
 	
     
 	if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+
+		//A new way to use the scipt : simply pass a proper object in the post body
+
 		$json = file_get_contents('php://input');
 		$data = json_decode($json);
 		$timeout = $data->timeout;
 		$proxy_type = $data->proxy_type;
 		$authentication = $data->authentication;
 		$proxies = $data->proxies;
+
+		//The structure of the function stays the same.
+		//@vasemkin
 		CheckMultiProxy($proxies, $timeout, $proxy_type, $authentication);
+
 	} else {
 
 		//Step 1 - Check whether the user specified a timeout
@@ -91,12 +98,15 @@
 		{
 			$parts = explode(':', trim($proxy));
 			$url = strtok(curPageURL(),'?');
+
+			//Authentication is optional, and an expantion to the main logic
 			if ($authentication) {
 				$data[] = $url . '?ip=' . $parts[0] . "&port=" . $parts[1] . "&login=" . $parts[2] . "&password=" . $parts[3] . "&timeout=" . $timeout . "&proxy_type=" . $proxy_type;
 			} else{
 				$data[] = $url . '?ip=' . $parts[0] . "&port=" . $parts[1] . "&timeout=" . $timeout . "&proxy_type=" . $proxy_type;
 			}
 		}
+
 		$results = multiRequest($data);
 		$holder = array();
 		foreach($results as $result)

--- a/checker.php
+++ b/checker.php
@@ -22,64 +22,80 @@
 	//To determine whether we are being supplied an ip-port or a filename, we'll take a look at the get params
 	
     
-	//Step 1 - Check whether the user specified a timeout
-	if(!isset($_GET['timeout']))
-	{
-		die("You must specify a timeout in seconds in your request (checker.php?...&timeout=20)");
-	}
-    
-    //Step 2 - Little extras go here 
-    //Default is 'false' not to confuse the IF-logic later on
-    $socksOnly = false;
-    if(isset($_GET['proxy_type']))
-    {
-        if($_GET['proxy_type'] == "socks")
-        {
-            $socksOnly = true;
-            $proxy_type = "socks";
-        }
-        else
-        {
-            $proxy_type = "http(s)";
-        }
-    }
-    else
-    {
-        $proxy_type = "http(s)";
-    }
+	if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+		$json = file_get_contents('php://input');
+		$data = json_decode($json);
+		$timeout = $data->timeout;
+		$proxy_type = $data->proxy_type;
+		$authentication = $data->authentication;
+		$proxies = $data->proxies;
+		CheckMultiProxy($proxies, $timeout, $proxy_type, $authentication);
+	} else {
 
-	//Step 3 - Go through a loop to determine what the user wants us to do
-	if(isset($_GET['file']))
-	{
-		//If we can't find the file, complain
-		if(!file_exists($_GET['file']))
+		//Step 1 - Check whether the user specified a timeout
+		if(!isset($_GET['timeout']))
 		{
-			die("Could not find file '" . $_GET['file'] . "'");
+			die("You must specify a timeout in seconds in your request (checker.php?...&timeout=20)");
 		}
 		
-		//Convert the file to a list of proxies
-		$array = file($_GET['file']);
-		CheckMultiProxy($array, $_GET['timeout'], $proxy_type);
-	}
-	else if(isset($_GET['ip']) && isset($_GET['port']))
-	{
-		CheckSingleProxy($_GET['ip'], $_GET['port'], $_GET['timeout'], $_GET['login'], $_GET['password'], true, $socksOnly, $proxy_type);
-	}
-	else
-	{
-		die("<h2>Could not find the required GET parameters.</h2><br /><b>To check a proxy use:</b><br /><i>checker.php?ip=...&port=...</i><br /><b>To go through a list of proxies (IP:PORT Format) use:</b><br /><i>checker.php?file=...</i>");
-	}
+		//Step 2 - Little extras go here 
+		//Default is 'false' not to confuse the IF-logic later on
+		$socksOnly = false;
+		if(isset($_GET['proxy_type']))
+		{
+			if($_GET['proxy_type'] == "socks")
+			{
+				$socksOnly = true;
+				$proxy_type = "socks";
+			}
+			else
+			{
+				$proxy_type = "http(s)";
+			}
+		}
+		else
+		{
+			$proxy_type = "http(s)";
+		}
 	
+		//Step 3 - Go through a loop to determine what the user wants us to do
+		if(isset($_GET['file']))
+		{
+			//If we can't find the file, complain
+			if(!file_exists($_GET['file']))
+			{
+				die("Could not find file '" . $_GET['file'] . "'");
+			}
+			
+			//Convert the file to a list of proxies
+			$array = file($_GET['file']);
+			CheckMultiProxy($array, $_GET['timeout'], $proxy_type, $_GET['authentication']);
+		}
+		else if(isset($_GET['ip']) && isset($_GET['port']))
+		{
+			CheckSingleProxy($_GET['ip'], $_GET['port'], $_GET['timeout'], $_GET['login'], $_GET['password'], true, $socksOnly, $proxy_type);
+		}
+		else
+		{
+			die("<h2>Could not find the required GET parameters.</h2><br /><b>To check a proxy use:</b><br /><i>checker.php?ip=...&port=...</i><br /><b>To go through a list of proxies (IP:PORT Format) use:</b><br /><i>checker.php?file=...</i>");
+		}
+		
+
+	}
 	
      
-    function CheckMultiProxy($proxies, $timeout, $proxy_type)
+    function CheckMultiProxy($proxies, $timeout, $proxy_type, $authentication=false)
 	{
 		$data = array();
 		foreach($proxies as $proxy)
 		{
 			$parts = explode(':', trim($proxy));
 			$url = strtok(curPageURL(),'?');
-			$data[] = $url . '?ip=' . $parts[0] . "&port=" . $parts[1] . "&timeout=" . $timeout . "&proxy_type=" . $proxy_type;
+			if ($authentication) {
+				$data[] = $url . '?ip=' . $parts[0] . "&port=" . $parts[1] . "&login=" . $parts[2] . "&password=" . $parts[3] . "&timeout=" . $timeout . "&proxy_type=" . $proxy_type;
+			} else{
+				$data[] = $url . '?ip=' . $parts[0] . "&port=" . $parts[1] . "&timeout=" . $timeout . "&proxy_type=" . $proxy_type;
+			}
 		}
 		$results = multiRequest($data);
 		$holder = array();

--- a/checker.php
+++ b/checker.php
@@ -63,7 +63,7 @@
 	}
 	else if(isset($_GET['ip']) && isset($_GET['port']))
 	{
-		CheckSingleProxy($_GET['ip'], $_GET['port'], $_GET['timeout'], true, $socksOnly, $proxy_type);
+		CheckSingleProxy($_GET['ip'], $_GET['port'], $_GET['timeout'], $_GET['login'], $_GET['password'], true, $socksOnly, $proxy_type);
 	}
 	else
 	{
@@ -94,11 +94,10 @@
      
 	 
 	 
-	 function CheckSingleProxy($ip, $port, $timeout, $echoResults=true, $socksOnly=false, $proxy_type="http(s)")
+	 function CheckSingleProxy($ip, $port, $timeout, $login=null, $password=null, $echoResults=true, $socksOnly=false, $proxy_type="http(s)")
 	 {
 		$passByIPPort= $ip . ":" . $port;
-		 
-		 
+		
 		// You can use virtually any website here, but in case you need to implement other proxy settings (show annonimity level)
 		// I'll leave you with whatismyipaddress.com, because it shows a lot of info.
 		$url = "http://whatismyipaddress.com/";
@@ -110,6 +109,13 @@
 		curl_setopt($theHeader, CURLOPT_RETURNTRANSFER, 1);
 		curl_setopt($theHeader, CURLOPT_TIMEOUT, $timeout);
 		curl_setopt($theHeader, CURLOPT_PROXY, $passByIPPort);
+
+		//Basic proxy authentication support by @vasemkin
+		if($login && $password) {
+			$proxyAuth = $login . ":" . $password;
+			curl_setopt($theHeader, CURLOPT_PROXYAUTH, CURLAUTH_BASIC);
+			curl_setopt($theHeader, CURLOPT_PROXYUSERPWD, $proxyAuth);
+		}
         
         //If only socks proxy checking is enabled, use this below.
         if($socksOnly)
@@ -132,7 +138,7 @@
             //Just as a safety net though, I'm still aborting if $socksOnly is true (i.e. we were initially checking for a socks-specific proxy)
             if(curl_errno($theHeader) == 56 && !$socksOnly)
             {
-                CheckSingleProxy($ip, $port, $timeout, $echoResults, true, "socks");
+                CheckSingleProxy($ip, $port, $timeout, $login, $password, $echoResults, true, "socks");
                 return;
             }
             


### PR DESCRIPTION
This pull request introduces the following features:

### Authentication
Added support for proxies that require authentication. 
```
checker.php?ip=ip&port=port&timeout=timeout&login=foo&password=bar
```

### POST request handling. 
To check multiple proxies, you can pass a request with body structured like this:
```json
{ 
    "timeout" : 20,
    "proxy_type" : "http(s)",
    "authentication" : true,
    "proxies" : ["ip:port:login:password", "ip:port:anotherproxy:password"]
}
```

The pull request expands on the existing codebase, and only adds new features